### PR TITLE
Replace pipeline image with TikZ diagram in dissertation

### DIFF
--- a/docs/dissertation.tex
+++ b/docs/dissertation.tex
@@ -1,6 +1,6 @@
 \documentclass{report}
 \usepackage{hyperref}
-\usepackage{graphicx}
+\usepackage{tikz}
 \title{Fake News Detection using NLP and Deep Learning}
 \author{TODO: Author Name}
 \date{\today}
@@ -15,6 +15,30 @@ TODO: Introduction text.
 \chapter{Literature Review}
 TODO: Literature review text.
 \chapter{Methodology}
+The workflow for detecting fake news is illustrated in Figure~\ref{fig:pipeline}.
+
+\begin{figure}[h]
+    \centering
+    \begin{tikzpicture}[
+        node distance=2.5cm,
+        >=stealth,
+        every node/.style={draw, rectangle, rounded corners, align=center, minimum width=2.8cm, minimum height=1.2cm}
+    ]
+        \node (data) {Raw\\Articles};
+        \node (prep) [right of=data] {Preprocessing};
+        \node (feat) [right of=prep] {Feature\\Extraction};
+        \node (model) [right of=feat] {Model\\Training};
+        \node (pred) [right of=model] {Prediction};
+
+        \draw[->] (data) -- (prep);
+        \draw[->] (prep) -- (feat);
+        \draw[->] (feat) -- (model);
+        \draw[->] (model) -- (pred);
+    \end{tikzpicture}
+    \caption{Processing pipeline used in this project.}
+    \label{fig:pipeline}
+\end{figure}
+
 TODO: Methodology details.
 \chapter{Experiments}
 TODO: Experiments and results.


### PR DESCRIPTION
## Summary
- Replace removed image with a TikZ-based pipeline diagram in `docs/dissertation.tex`.
- Drop `graphicx` image dependency and embed a textual diagram.

## Testing
- `pdflatex docs/dissertation.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f9b316948324823d2f0bdc684820