### PR TITLE
docs: add latex build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ __pycache__/
 *.pyd
 env/
 venv/
+# LaTeX build artifacts
+docs/*.aux
+docs/*.bbl
+docs/*.blg
+docs/*.log
+docs/*.out
+docs/*.toc
+docs/*.pdf

--- a/README.md
+++ b/README.md
@@ -32,3 +32,26 @@ python manage.py runserver
 ## Notes
 
 The project is under active development. Many components are placeholders and require further implementation.
+
+## Documentation
+
+### Prerequisites
+
+Building the dissertation PDF requires a LaTeX distribution such as [TeX Live](https://www.tug.org/texlive/).
+
+### Building the PDF
+
+```bash
+cd docs
+pdflatex dissertation.tex
+bibtex dissertation
+pdflatex dissertation.tex
+pdflatex dissertation.tex
+```
+
+To automate the build, run:
+
+```bash
+cd docs
+make
+```

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,15 @@
+PDF = dissertation.pdf
+TEX = dissertation.tex
+
+all: $(PDF)
+
+$(PDF): $(TEX) refs.bib
+	pdflatex $(TEX)
+	bibtex dissertation
+	pdflatex $(TEX)
+	pdflatex $(TEX)
+
+clean:
+	rm -f dissertation.aux dissertation.bbl dissertation.blg dissertation.log dissertation.out dissertation.toc $(PDF)
+
+.PHONY: all clean


### PR DESCRIPTION
## Summary
- document TeX Live prerequisite and explicit pdflatex/bibtex steps for building dissertation PDF
- add Makefile to automate PDF generation
- ignore LaTeX build artifacts

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*
- `cd docs && make` *(fails: pdflatex: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f9c593788324ab0d2b01a1138909